### PR TITLE
remove unecessary fortran options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.eggs/*
+*.egg-info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ['setuptools', 'wheel', 'numpy']
+requires = ['setuptools', 'wheel', 'numpy < 2']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ['setuptools>=40.8.0', 'wheel', 'numpy >= 1.3.0']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ['setuptools>=40.8.0', 'wheel', 'numpy >= 1.3.0']
+requires = ['setuptools<58.5', 'wheel', 'numpy >= 1.3.0']

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ from distutils.core import Extension, setup
 from numpy import get_include
 from os.path import join
 import os
-import sys
 
 # possible types
 types = ("int", "long", "float", "double")
@@ -26,14 +25,14 @@ for t in types:
 # distutils
 
 setup(name='fht',
-      version='1.0.1',
+      version='1.0.2',
       description='Fast Hadamard Transform',
       author='Nicolas Barbey',
       author_email='nicolas.a.barbey@gmail.com',
-      requires=['numpy (>1.3.0)'],
       packages=['fht'],
       ext_modules=[Extension('fht._C_fht_%(ctype)s' % {"ctype":t},
                              [join('fht', 'C_fht_%(ctype)s.c') % {"ctype":t}],
                              include_dirs=[join(get_include(), 'numpy')], )
+                             #include_dirs=[get_include()], )
                    for t in types],
       )

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from numpy.distutils.core import Extension, setup
+from distutils.core import Extension, setup
 from numpy import get_include
 from os.path import join
 import os
@@ -35,5 +35,4 @@ setup(name='fht',
                              [join('fht', 'C_fht_%(ctype)s.c') % {"ctype":t}],
                              include_dirs=[join(get_include(), 'numpy')], )
                    for t in types],
-      data_files=[('tests', ['test_fht'])]
       )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+import setuptools
+
+setuptools.setup(setup_requires=['numpy'])
+
 from numpy.distutils.core import Extension, setup
 from numpy import get_include
 from os.path import join

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ for t in types:
 
 # distutils
 
-sys.path.extend('config_fc --fcompiler=gnu95 --f90flags=-fopenmp --f90exec=/usr/bin/gfortran '.split())
 setup(name='fht',
       version='1.0.1',
       description='Fast Hadamard Transform',
@@ -34,9 +33,7 @@ setup(name='fht',
       packages=['fht'],
       ext_modules=[Extension('fht._C_fht_%(ctype)s' % {"ctype":t},
                              [join('fht', 'C_fht_%(ctype)s.c') % {"ctype":t}],
-                             include_dirs=[join(get_include(), 'numpy')],
-                             extra_compile_args=['-fopenmp'],
-                             extra_link_args=['-fopenmp'],)
+                             include_dirs=[join(get_include(), 'numpy')], )
                    for t in types],
       data_files=[('tests', ['test_fht'])]
       )


### PR DESCRIPTION
It looks like some fortran bits from another project made it into setup.py. This patch removes these bits so it builds on systems w/o fortran installed.