### PR TITLE
Add pyproject file so pip knows the build requirements.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ['setuptools>=40.8.0', 'wheel', 'numpy >= 1.3.0']


### PR DESCRIPTION
This change will allow pip to know to install NumPy before building. 